### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/1.4/Source/Harmony/MainTabWindow_MintResearch_SetTargetProject_Patch.cs
+++ b/1.4/Source/Harmony/MainTabWindow_MintResearch_SetTargetProject_Patch.cs
@@ -9,7 +9,7 @@ namespace VanillaVehiclesExpanded
     [HarmonyPatch]
     public static class MainTabWindow_MintResearch_SetTargetProject_Patch
     {
-        public static bool Prepare() => ModsConfig.IsActive("Dubwise.DubsMintMenus");
+        public static bool Prepare() => ModsConfig.IsActive("Dubwise.DubsMintMenus") || ModsConfig.IsActive("Dubwise.DubsMintMenus_steam");
 
         [HarmonyTargetMethods]
         public static IEnumerable<MethodBase> TargetMethods()


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72